### PR TITLE
fix(README): add missing dash character

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -31,7 +31,7 @@ python manage.py migrate
 
 6- spin off docker compose
 ```
-docker compose -f docker-compose.dev.yml up -d
+docker-compose -f docker-compose.dev.yml up -d
 ```
 
 7- run the project


### PR DESCRIPTION
In the command "docker compose -f docker-compose.dev.yml up -d", there is a missing "-" between docker and compose.